### PR TITLE
Set Visible CUDA Device to "1" to avoid memory errors

### DIFF
--- a/run_gecko_emulators.py
+++ b/run_gecko_emulators.py
@@ -5,7 +5,9 @@ import time
 import tensorflow as tf
 from geckoml.box import GeckoBoxEmulator
 from geckoml.metrics import ensembled_box_metrics, mae_time_series, match_true_exps
+import os
 
+os.environ["CUDA_VISIBLE_DEVICES"] = "1"
 gpus = tf.config.experimental.list_physical_devices('GPU')
 for device in gpus:
     print(device)


### PR DESCRIPTION
This line helps avoid CUDA memory errors when running the box model without GPUs. I believe TF 2.0+ automatically looks for GPUs, even though the batch script does not allocate them which was problematic.